### PR TITLE
Forwarded the Event and Reason

### DIFF
--- a/src/components/inputs/Autocomplete/Autocomplete.test.tsx
+++ b/src/components/inputs/Autocomplete/Autocomplete.test.tsx
@@ -96,7 +96,7 @@ describe('Single-value Autocomplete', () => {
       act(() => userClick(screen.getByText('Add "new"')))
 
       await waitFor(() => {
-        expect(mockOnChange).toBeCalledWith({ id: 'new', displayName: 'new' })
+        expect(mockOnChange).toBeCalledWith({ id: 'new', displayName: 'new' }, expect.anything(), 'selectOption')
       })
     })
 
@@ -117,7 +117,7 @@ describe('Single-value Autocomplete', () => {
       act(() => userClick(screen.getByText('Add "new"')))
 
       await waitFor(() => {
-        expect(mockOnChange).toBeCalledWith('new')
+        expect(mockOnChange).toBeCalledWith('new', expect.anything(), 'selectOption')
       })
     })
   })
@@ -161,7 +161,7 @@ describe('Single-value Autocomplete', () => {
       const options = screen.getAllByRole('option')
       act(() => userClick(options[0]))
 
-      expect(mockOnChange).toBeCalledWith('first option')
+      expect(mockOnChange).toBeCalledWith('first option', expect.anything(), 'selectOption')
     })
 
     test('calls onChange with value of id by default', () => {
@@ -170,7 +170,7 @@ describe('Single-value Autocomplete', () => {
       const options = screen.getAllByRole('option')
       act(() => userClick(options[0]))
 
-      expect(mockOnChange).toBeCalledWith(1)
+      expect(mockOnChange).toBeCalledWith(1, expect.anything(), 'selectOption')
     })
 
     test('can display a value that is number', () => {
@@ -191,7 +191,7 @@ describe('Single-value Autocomplete', () => {
       const options = screen.getAllByRole('option')
       act(() => userClick(options[0]))
 
-      expect(mockOnChange).toBeCalledWith(basicOptions[0])
+      expect(mockOnChange).toBeCalledWith(basicOptions[0], expect.anything(), 'selectOption')
     })
   })
 
@@ -207,7 +207,7 @@ describe('Single-value Autocomplete', () => {
       const options = screen.getAllByRole('option')
       act(() => userClick(options[0]))
 
-      expect(mockOnChange).toBeCalledWith('first option')
+      expect(mockOnChange).toBeCalledWith('first option', expect.anything(), 'selectOption')
     })
 
     test('displays selected option in input for numeric options', () => {
@@ -220,7 +220,7 @@ describe('Single-value Autocomplete', () => {
       render(<Autocomplete open options={numericOptions} onChange={mockOnChange} />)
       const options = screen.getAllByRole('option')
       act(() => userClick(options[0]))
-      expect(mockOnChange).toBeCalledWith(1)
+      expect(mockOnChange).toBeCalledWith(1, expect.anything(), 'selectOption')
     })
   })
 })
@@ -266,7 +266,7 @@ describe('Multi-value Autocomplete', () => {
     act(() => userClick(screen.getByTitle('Clear')))
 
     await waitFor(() => {
-      expect(mockOnChange).toBeCalledWith([basicOptions[1].id])
+      expect(mockOnChange).toBeCalledWith([basicOptions[1].id], expect.anything(), 'clear')
     })
   })
 
@@ -335,7 +335,7 @@ describe('Multi-value Autocomplete', () => {
       const options = screen.getAllByRole('option')
       act(() => userClick(options[0]))
 
-      expect(mockOnChange).toBeCalledWith(['first option'])
+      expect(mockOnChange).toBeCalledWith(['first option'], expect.anything(), 'selectOption')
     })
 
     test('can display a value that is number', () => {
@@ -377,7 +377,11 @@ describe('Multi-value Autocomplete', () => {
       const options = screen.getAllByRole('option')
       act(() => userClick(options[0]))
 
-      expect(mockOnChange).toBeCalledWith([{ id: 1, name: 'first option', displayName: 'First Option' }])
+      expect(mockOnChange).toBeCalledWith(
+        [{ id: 1, name: 'first option', displayName: 'First Option' }],
+        expect.anything(),
+        'selectOption'
+      )
     })
   })
 })

--- a/src/components/inputs/Autocomplete/Autocomplete.tsx
+++ b/src/components/inputs/Autocomplete/Autocomplete.tsx
@@ -192,23 +192,23 @@ const Autocomplete: React.FC<AutocompleteProps<any, any, any, any>> = ({
   )
 
   const handleChange = useCallback(
-    (_event: React.SyntheticEvent, inputValue: any, reason: AutocompleteChangeReason) => {
+    (event: React.SyntheticEvent, inputValue: any, reason: AutocompleteChangeReason) => {
       // when multi-value and clearable, doesn't clear disabled options that have already been selected
       if (reason === 'clear' && getOptionDisabled && isMultiSelection) {
-        return onChange(computeChangedMultiValue(disabledOptions, simpleValue, valueKey, labelKey))
+        return onChange(computeChangedMultiValue(disabledOptions, simpleValue, valueKey, labelKey), event, reason)
       }
 
       setLocalInput(handleOptionLabel(inputValue))
       // for multi-value Autocomplete, options dialog remains open after selection and we do not want to display a loading state
       if (loadOptions && !isMultiSelection) setLocalLoading(true)
 
-      if (isNil(inputValue) || isStringOrNumber(inputValue)) return onChange(inputValue)
+      if (isNil(inputValue) || isStringOrNumber(inputValue)) return onChange(inputValue, event, reason)
 
       if (isMultiSelection) {
-        return onChange(computeChangedMultiValue(inputValue, simpleValue, valueKey, labelKey))
+        return onChange(computeChangedMultiValue(inputValue, simpleValue, valueKey, labelKey), event, reason)
       }
 
-      return onChange(computeChangedSingleValue(inputValue, simpleValue, valueKey, labelKey))
+      return onChange(computeChangedSingleValue(inputValue, simpleValue, valueKey, labelKey), event, reason)
     },
     [
       disabledOptions,


### PR DESCRIPTION
The `Autocomplete` type for `onChange` is saying that it will call the function with `(value, event?, reason?)` but the code never forwarded those last 2 parameters.
This change will fix issue #42 