### PR TITLE
Toggle CollapseCard on header click option

### DIFF
--- a/src/components/surfaces/Card/types.ts
+++ b/src/components/surfaces/Card/types.ts
@@ -91,7 +91,7 @@ export interface CardProps extends Omit<MuiCardProps, 'title'> {
   /**
    * Actions to be displayed in the upper right corner of the card. If an array, will display all items with spacing between them.
    */
-  actions?: React.ReactNode
+  actions?: React.ReactNode | React.ReactNode[]
   /**
    * Props applied to the CardActions component.
    */

--- a/src/components/surfaces/CollapseCard/CollapseCard.tsx
+++ b/src/components/surfaces/CollapseCard/CollapseCard.tsx
@@ -5,7 +5,7 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import ExpandLessIcon from '@mui/icons-material/ExpandLess'
 import { Card, IconButton } from '../../index'
 import { CollapseCardProps } from './types'
-import { Box, CardContent } from '@mui/material'
+import { CardContent, Grid } from '@mui/material'
 
 /**
  * A Collapse Card is basically a 'smarter' Card component that allows users to toggle the display of content by expanding or collapsing the card.
@@ -56,7 +56,9 @@ const CollapseCard: React.FC<CollapseCardProps> = ({
     <Card
       disablePadding
       actions={
-        <Box onClick={handleActionsClick}>{Array.isArray(actions) ? [...actions, iconButton] : [actions, iconButton]}</Box>
+        <Grid container gap={1} onClick={handleActionsClick}>
+          {Array.isArray(actions) ? [...actions, iconButton] : [actions, iconButton]}
+        </Grid>
       }
       variant={variant}
       headerProps={headerProps}

--- a/src/components/surfaces/CollapseCard/CollapseCard.tsx
+++ b/src/components/surfaces/CollapseCard/CollapseCard.tsx
@@ -5,7 +5,7 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import ExpandLessIcon from '@mui/icons-material/ExpandLess'
 import { Card, IconButton } from '../../index'
 import { CollapseCardProps } from './types'
-import { CardContent, Grid } from '@mui/material'
+import { CardContent, Stack } from '@mui/material'
 
 /**
  * A Collapse Card is basically a 'smarter' Card component that allows users to toggle the display of content by expanding or collapsing the card.
@@ -56,9 +56,11 @@ const CollapseCard: React.FC<CollapseCardProps> = ({
     <Card
       disablePadding
       actions={
-        <Grid container gap={1} onClick={handleActionsClick}>
-          {Array.isArray(actions) ? [...actions, iconButton] : [actions, iconButton]}
-        </Grid>
+        <Stack direction="row" spacing={1} onClick={handleActionsClick}>
+          {(Array.isArray(actions) ? [...actions, iconButton] : [actions, iconButton]).map((action, index) => (
+            <React.Fragment key={index}>{action}</React.Fragment>
+          ))}
+        </Stack>
       }
       variant={variant}
       headerProps={headerProps}

--- a/src/components/surfaces/CollapseCard/CollapseCard.tsx
+++ b/src/components/surfaces/CollapseCard/CollapseCard.tsx
@@ -5,7 +5,7 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import ExpandLessIcon from '@mui/icons-material/ExpandLess'
 import { Card, IconButton } from '../../index'
 import { CollapseCardProps } from './types'
-import { CardContent } from '@mui/material'
+import { Box, CardContent } from '@mui/material'
 
 /**
  * A Collapse Card is basically a 'smarter' Card component that allows users to toggle the display of content by expanding or collapsing the card.
@@ -43,10 +43,21 @@ const CollapseCard: React.FC<CollapseCardProps> = ({
     return { sx: { cursor: 'pointer' }, onClick: toggleCard }
   }, [toggleOnHeaderClick, toggleCard])
 
+  const handleActionsClick = useCallback(
+    (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+      /* Stop click event propagation on card actions to prevent card toggle (if toggleOnHeaderClick is enabled) */
+      if (!toggleOnHeaderClick) return
+      event.stopPropagation()
+    },
+    [toggleOnHeaderClick]
+  )
+
   return (
     <Card
       disablePadding
-      actions={Array.isArray(actions) ? [...actions, iconButton] : [actions, iconButton]}
+      actions={
+        <Box onClick={handleActionsClick}>{Array.isArray(actions) ? [...actions, iconButton] : [actions, iconButton]}</Box>
+      }
       variant={variant}
       headerProps={headerProps}
       subheader={hideSubheaderOnExpand && exp ? <></> : subheader}
@@ -108,7 +119,12 @@ CollapseCard.propTypes = {
    * If true, the subheader will be hidden when the card is expanded.
    * @default false
    */
-  hideSubheaderOnExpand: PropTypes.bool
+  hideSubheaderOnExpand: PropTypes.bool,
+  /**
+   * If true, the card will toggle when clicking on the whole header, not just the expand button.
+   * @default false
+   */
+  toggleOnHeaderClick: PropTypes.bool
 }
 
 export default CollapseCard

--- a/src/components/surfaces/CollapseCard/CollapseCard.tsx
+++ b/src/components/surfaces/CollapseCard/CollapseCard.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react'
+import React, { useCallback, useMemo, useState } from 'react'
 import Collapse from '@mui/material/Collapse'
 import PropTypes from 'prop-types'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
@@ -20,6 +20,7 @@ const CollapseCard: React.FC<CollapseCardProps> = ({
   onToggle,
   subheader,
   hideSubheaderOnExpand = false,
+  toggleOnHeaderClick = false,
   ...rest
 }) => {
   const [localExpanded, setLocalExpanded] = useState(defaultExpanded || false)
@@ -37,11 +38,17 @@ const CollapseCard: React.FC<CollapseCardProps> = ({
     </IconButton>
   )
 
+  const headerProps = useMemo(() => {
+    if (!toggleOnHeaderClick) return undefined
+    return { sx: { cursor: 'pointer' }, onClick: toggleCard }
+  }, [toggleOnHeaderClick, toggleCard])
+
   return (
     <Card
       disablePadding
       actions={Array.isArray(actions) ? [...actions, iconButton] : [actions, iconButton]}
       variant={variant}
+      headerProps={headerProps}
       subheader={hideSubheaderOnExpand && exp ? <></> : subheader}
       {...rest}
     >

--- a/src/components/surfaces/CollapseCard/types.ts
+++ b/src/components/surfaces/CollapseCard/types.ts
@@ -32,4 +32,8 @@ export interface CollapseCardProps extends Omit<CardProps, 'content'> {
    * If true, the subheader will be hidden when the card is expanded.
    */
   hideSubheaderOnExpand?: boolean
+  /**
+   * If true, the card will toggle when clicking on the whole header, not just the expand button.
+   */
+  toggleOnHeaderClick?: boolean
 }

--- a/src/stories/surfaces/CollapseCard/CollapseCard.stories.tsx
+++ b/src/stories/surfaces/CollapseCard/CollapseCard.stories.tsx
@@ -181,3 +181,25 @@ export const Controlled: Story = {
   },
   render: () => <ControlledPreview />
 }
+
+/**
+ * The card can be toggled by clicking on the whole header with the 'toggleOnHeaderClick' option
+ */
+export const WithToggleOnHeaderClick: Story = {
+  args: { title, subheader, content, onToggle: undefined, toggleOnHeaderClick: true },
+  parameters: {
+    docs: {
+      source: {
+        code: `
+        <CollapseCard 
+          title={'Card Title'} 
+          subheader={'Subheader'} 
+          content={--Text content here--} 
+          toggleOnHeaderClick
+        />
+        `,
+        format: true
+      }
+    }
+  }
+}

--- a/src/stories/surfaces/CollapseCard/CollapseCard.stories.tsx
+++ b/src/stories/surfaces/CollapseCard/CollapseCard.stories.tsx
@@ -186,7 +186,7 @@ export const Controlled: Story = {
  * The card can be toggled by clicking on the whole header with the 'toggleOnHeaderClick' option
  */
 export const WithToggleOnHeaderClick: Story = {
-  args: { title, subheader, content, onToggle: undefined, toggleOnHeaderClick: true },
+  args: { title, subheader, content, onToggle: undefined, actions, toggleOnHeaderClick: true },
   parameters: {
     docs: {
       source: {


### PR DESCRIPTION
Added a configurable option for CollapseCard (toggleOnHeaderClick) that allows the card to be toggled by clicking on the whole header.