### PR TITLE
Remove Typography title wrap in Accordion

### DIFF
--- a/src/components/surfaces/Accordion/Accordion.tsx
+++ b/src/components/surfaces/Accordion/Accordion.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useState } from 'react'
+import React, { ReactNode, useState, isValidElement } from 'react'
 import PropTypes from 'prop-types'
 import { Accordion as MuiAccordion, AccordionDetails } from '@mui/material/'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
@@ -18,12 +18,13 @@ const AccordionItem: React.FC<AccordionProps> = ({
   return (
     <MuiAccordion defaultExpanded={isBoolean(defaultExpanded) ? defaultExpanded : false} {...rest}>
       <AccordionSummary variant={'standard' as AccordionVariant} expandIcon={<ExpandMoreIcon />} {...summaryProps}>
-        {typeof title === 'string' && (
+        {isValidElement(title) ? (
+          title
+        ) : (
           <Typography variant="subtitle1" color={'textPrimary'}>
             {title}
           </Typography>
         )}
-        {typeof title !== 'string' && title}
       </AccordionSummary>
       <AccordionDetails {...detailsProps}>{content as ReactNode}</AccordionDetails>
     </MuiAccordion>

--- a/src/components/surfaces/Accordion/Accordion.tsx
+++ b/src/components/surfaces/Accordion/Accordion.tsx
@@ -18,13 +18,14 @@ const AccordionItem: React.FC<AccordionProps> = ({
   return (
     <MuiAccordion defaultExpanded={isBoolean(defaultExpanded) ? defaultExpanded : false} {...rest}>
       <AccordionSummary variant={'standard' as AccordionVariant} expandIcon={<ExpandMoreIcon />} {...summaryProps}>
-        <Typography variant="subtitle1" color={'textPrimary'}>
-          {title}
-        </Typography>
+        {typeof title === 'string' && (
+          <Typography variant="subtitle1" color={'textPrimary'}>
+            {title}
+          </Typography>
+        )}
+        {typeof title !== 'string' && title}
       </AccordionSummary>
-      <AccordionDetails {...detailsProps}>
-        {content as ReactNode}
-      </AccordionDetails>
+      <AccordionDetails {...detailsProps}>{content as ReactNode}</AccordionDetails>
     </MuiAccordion>
   )
 }


### PR DESCRIPTION
Remove Typography title wrap in Accordion for non string titles (ex. when passing a Grid or any other component)