### PR TITLE
Resolve multiselect autocomplete label overflow and search filter reset issues

### DIFF
--- a/src/components/inputs/Autocomplete/Autocomplete.tsx
+++ b/src/components/inputs/Autocomplete/Autocomplete.tsx
@@ -77,6 +77,8 @@ const Autocomplete: React.FC<AutocompleteProps<any, any, any, any>> = ({
   const [localLoading, setLocalLoading] = useState(false)
   const loading = receivedLoading || localLoading
 
+  const [multiselectSearchInput, setMultiselectSearchInput] = React.useState('')
+
   const [localInput, setLocalInput] = useState<string>()
   const [optionsLoaded, setOptionsLoaded] = useState(false)
 
@@ -162,12 +164,13 @@ const Autocomplete: React.FC<AutocompleteProps<any, any, any, any>> = ({
           startAdornment={params.InputProps.startAdornment}
           endAdornment={params.InputProps.endAdornment}
           {...textFieldProps}
+          onChange={isMultiSelection && isSearchable ? setMultiselectSearchInput : undefined}
           InputProps={{ ...params.InputProps, margin: 'none' }}
           InputLabelProps={{ ...params.InputLabelProps, margin: null }}
         />
       )
     },
-    [inputSelectedColor, isSearchable, label, error, helperText, required, placeholder, inputTextFieldProps]
+    [inputSelectedColor, isSearchable, label, error, helperText, required, placeholder, inputTextFieldProps, isMultiSelection]
   )
 
   const handleOptionLabel = useCallback(
@@ -313,6 +316,7 @@ const Autocomplete: React.FC<AutocompleteProps<any, any, any, any>> = ({
       typographyContentColor={typographyContentColor}
       forcePopupIcon
       label={label}
+      inputValue={isMultiSelection && isSearchable ? multiselectSearchInput : undefined}
       disabled={disabled || isValueDisabled}
       loading={loading}
       loadingText={loadingText ?? <LinearProgress />}

--- a/src/components/inputs/TextField/TextField.tsx
+++ b/src/components/inputs/TextField/TextField.tsx
@@ -177,10 +177,10 @@ const TextField: React.FC<TextFieldProps> = ({
   const internalStartAdornment = useMemo(() => {
     if (!isStepper && !startAdornment) return null
     return (
-      <InputAdornment position="start">
-        {isStepper && <SubtractButton onSubtract={handleSubtract} />}
+      <>
+        {isStepper && <InputAdornment position="start"><SubtractButton onSubtract={handleSubtract} /></InputAdornment>}
         {startAdornment}
-      </InputAdornment>
+      </>
     )
   }, [handleSubtract, isStepper, startAdornment])
 


### PR DESCRIPTION
Fixes an options label overflow issue due to improper nesting of InputAdornment tags and prevents the search string from resetting for multiselect autocomplete by using a controlled input component