### PR TITLE
Use controlled search input for multiselect autocomplete

### DIFF
--- a/src/components/inputs/Autocomplete/Autocomplete.tsx
+++ b/src/components/inputs/Autocomplete/Autocomplete.tsx
@@ -77,6 +77,8 @@ const Autocomplete: React.FC<AutocompleteProps<any, any, any, any>> = ({
   const [localLoading, setLocalLoading] = useState(false)
   const loading = receivedLoading || localLoading
 
+  const [multiselectSearchInput, setMultiselectSearchInput] = React.useState('')
+
   const [localInput, setLocalInput] = useState<string>()
   const [optionsLoaded, setOptionsLoaded] = useState(false)
 
@@ -162,12 +164,13 @@ const Autocomplete: React.FC<AutocompleteProps<any, any, any, any>> = ({
           startAdornment={params.InputProps.startAdornment}
           endAdornment={params.InputProps.endAdornment}
           {...textFieldProps}
+          onChange={isMultiSelection && isSearchable ? setMultiselectSearchInput : undefined}
           InputProps={{ ...params.InputProps, margin: 'none' }}
           InputLabelProps={{ ...params.InputLabelProps, margin: null }}
         />
       )
     },
-    [inputSelectedColor, isSearchable, label, error, helperText, required, placeholder, inputTextFieldProps]
+    [inputSelectedColor, isSearchable, label, error, helperText, required, placeholder, inputTextFieldProps, isMultiSelection]
   )
 
   const handleOptionLabel = useCallback(
@@ -313,6 +316,7 @@ const Autocomplete: React.FC<AutocompleteProps<any, any, any, any>> = ({
       typographyContentColor={typographyContentColor}
       forcePopupIcon
       label={label}
+      inputValue={isMultiSelection && isSearchable ? multiselectSearchInput : undefined}
       disabled={disabled || isValueDisabled}
       loading={loading}
       loadingText={loadingText ?? <LinearProgress />}


### PR DESCRIPTION
Prevents the search string from resetting for multiselect autocomplete by using a controlled input component