### PR TITLE
Fixed Autocomplete search reset issue

### DIFF
--- a/src/components/inputs/Autocomplete/Autocomplete.tsx
+++ b/src/components/inputs/Autocomplete/Autocomplete.tsx
@@ -325,6 +325,10 @@ const Autocomplete: React.FC<AutocompleteProps<any, any, any, any>> = ({
     [ListboxProps, handleLoadOptions, hasMore, isPaginated, localInput]
   )
 
+  const localValue = useMemo(() => {
+    return simpleValue ? getSimpleValue(loadOptions ? asyncOptions : options, value, valueKey, isMultiSelection) : value
+  }, [simpleValue, loadOptions, asyncOptions, options, value, valueKey, isMultiSelection])
+
   return (
     <MuiAutocomplete
       noOptionsText={<NoOptionsText color={typographyContentColor}>{noOptionsText}</NoOptionsText>}
@@ -348,7 +352,7 @@ const Autocomplete: React.FC<AutocompleteProps<any, any, any, any>> = ({
       getOptionLabel={handleOptionLabel}
       isOptionEqualToValue={isOptionEqualToValue}
       getOptionDisabled={getOptionDisabled}
-      value={simpleValue ? getSimpleValue(loadOptions ? asyncOptions : options, value, valueKey, isMultiSelection) : value}
+      value={localValue}
       multiple={isMultiSelection}
       onChange={handleChange}
       onInputChange={handleInputChange}


### PR DESCRIPTION
Fixed an Autocompete issue where the value of the search input would reset instantly on change when `simpleValue` and `isMultiSelection` are enabled.

This happened in a `useEffect` in `mui-base`'s `useAutocomplete` where the value of the search input was reset if the input was focused AND the value of the Autocomplete changed meanwhile. Since the value was NOT memoized in rocket, this triggered the reset.

The value is now memoized.