### PR TITLE
Add ToastContainerProps custom type for useToast

### DIFF
--- a/src/components/feedback/Toast/ToastContainer.tsx
+++ b/src/components/feedback/Toast/ToastContainer.tsx
@@ -11,7 +11,6 @@ import { ToastContainerProps } from './types'
 
 const ToastContainer: React.FC<ToastContainerProps> = ({
   position = toast.POSITION.TOP_CENTER,
-  autoClose = false,
   newestOnTop = true,
   transitionType = 'Slide',
   limit = 5,
@@ -22,7 +21,6 @@ const ToastContainer: React.FC<ToastContainerProps> = ({
       <ReactToastify
         className={classes.toastWrapper}
         position={position}
-        autoClose={autoClose}
         newestOnTop={newestOnTop}
         transition={transitionType as any}
         theme="colored"

--- a/src/components/feedback/Toast/types.ts
+++ b/src/components/feedback/Toast/types.ts
@@ -8,10 +8,4 @@ export interface ToastContainerProps extends Omit<ReactToastifyProps, 'transitio
    * @default Slide
    */
   transitionType?: 'Slide' | 'Bounce' | 'Zoom' | 'Flip'
-  /**
-   * Set the delay in ms to close the toast automatically.
-   * Use `false` to prevent the toast from closing.
-   * `Default: false`
-   */
-  autoClose?: number | false
 }

--- a/src/components/feedback/Toast/useToast.ts
+++ b/src/components/feedback/Toast/useToast.ts
@@ -9,13 +9,10 @@ import {
   ToastOptions as ToastifyToastOptions,
   TypeOptions as ToastifyTypeOptions
 } from 'react-toastify'
+import { ToastContainerProps } from './types'
 import { classes } from './ToastStyles'
 import cx from 'classnames'
 import { cond, equals, always, T } from 'ramda'
-
-type ToastOptions = Omit<ToastifyToastOptions, 'transition'> & {
-  transitionType?: 'Slide' | 'Bounce' | 'Zoom' | 'Flip'
-}
 
 const useToast = () => {
   return useCallback(
@@ -23,9 +20,9 @@ const useToast = () => {
      *
      * @param {ToastContent} message The content to be displayed
      * @param {('success'|'info'|'warning'|'error')} variant The type of the toast
-     * @param {ToastOptions} options Additional options passed to the toast
+     * @param {ToastContainerProps} options Additional options passed to the toast
      */
-    (message: ToastContent, variant?: ToastifyTypeOptions, { transitionType, ...restOptions } = {} as ToastOptions) => {
+    (message: ToastContent, variant?: ToastifyTypeOptions, { transitionType, ...restOptions } = {} as ToastContainerProps) => {
       const toastClasses = cx({
         [classes[variant]]: variant,
         [classes['default']]: true

--- a/src/components/feedback/Toast/useToast.ts
+++ b/src/components/feedback/Toast/useToast.ts
@@ -9,10 +9,13 @@ import {
   ToastOptions as ToastifyToastOptions,
   TypeOptions as ToastifyTypeOptions
 } from 'react-toastify'
-import { ToastContainerProps } from './types'
 import { classes } from './ToastStyles'
 import cx from 'classnames'
 import { cond, equals, always, T } from 'ramda'
+
+type ToastOptions = Omit<ToastifyToastOptions, 'transition'> & {
+  transitionType?: 'Slide' | 'Bounce' | 'Zoom' | 'Flip'
+}
 
 const useToast = () => {
   return useCallback(
@@ -20,9 +23,9 @@ const useToast = () => {
      *
      * @param {ToastContent} message The content to be displayed
      * @param {('success'|'info'|'warning'|'error')} variant The type of the toast
-     * @param {ToastContainerProps} options Additional options passed to the toast
+     * @param {ToastOptions} options Additional options passed to the toast
      */
-    (message: ToastContent, variant?: ToastifyTypeOptions, { transitionType, ...restOptions } = {} as ToastContainerProps) => {
+    (message: ToastContent, variant?: ToastifyTypeOptions, { transitionType, ...restOptions } = {} as ToastOptions) => {
       const toastClasses = cx({
         [classes[variant]]: variant,
         [classes['default']]: true


### PR DESCRIPTION
In #125 pull request, the intended outcome of having the tooltip documentation read as "Default: 5000" for autoClose paramiter was not reached. This pull request aims to fix that.