### PR TITLE
remove card header padding when only avatar

### DIFF
--- a/src/components/surfaces/Card/Card.tsx
+++ b/src/components/surfaces/Card/Card.tsx
@@ -76,7 +76,11 @@ const Card: React.FC<CardProps> = ({
         />
       )}
       {mediaProps && <CardMedia {...sizes[size || 's']} {...standardMediaProps} />}
-      {disablePadding ? children : <CardContent hasHeader={hasHeader} children={children} {...contentProps} />}
+      {disablePadding ? (
+        children
+      ) : (
+        <CardContent hasHeader={hasHeader} hasIcon={hasIcon} children={children} {...contentProps} />
+      )}
       {footer && (
         <CardActions filled={filled} {...footerProps}>
           {footer}

--- a/src/components/surfaces/Card/CardHeader/CardHeaderStyles.ts
+++ b/src/components/surfaces/Card/CardHeader/CardHeaderStyles.ts
@@ -26,7 +26,8 @@ const CardHeader = styled(MuiCardHeader, {
     headerContentProps
   }: Partial<StyledProps>) => ({
     ['&.MuiCardHeader-root']: {
-      ...(filled && { backgroundColor: theme?.palette.grey[200], minHeight: '48px' })
+      ...(filled && { backgroundColor: theme?.palette.grey[200], minHeight: '48px' }),
+      ...(hasIcon ? { padding: 0 } : {})
     },
     ['& .MuiCardHeader-avatar']: {
       ...(hasIcon && {

--- a/src/components/surfaces/Card/CardStyles.ts
+++ b/src/components/surfaces/Card/CardStyles.ts
@@ -52,10 +52,10 @@ const Card = styled(BaseCard, {
 })
 
 export const CardContent = styled(BaseCardContent, {
-  shouldForwardProp: prop => !includes(prop, ['hasHeader'])
-})(({ hasHeader }: { hasHeader: boolean }) => {
+  shouldForwardProp: prop => !includes(prop, ['hasHeader', 'hasIcon'])
+})(({ hasHeader, hasIcon }: { hasHeader: boolean; hasIcon: boolean }) => {
   return {
-    padding: hasHeader ? '8px 24px 24px 24px' : '24px'
+    padding: !hasHeader || hasIcon ? '24px' : '8px 24px 24px 24px'
   }
 })
 


### PR DESCRIPTION
Card header padding is now 0 when the only element that is drawn inside Header is the avatar