### PR TITLE
Remove setting padding to 0 when card header contains icon

### DIFF
--- a/src/components/surfaces/Card/CardHeader/CardHeaderStyles.ts
+++ b/src/components/surfaces/Card/CardHeader/CardHeaderStyles.ts
@@ -26,8 +26,7 @@ const CardHeader = styled(MuiCardHeader, {
     headerContentProps
   }: Partial<StyledProps>) => ({
     ['&.MuiCardHeader-root']: {
-      ...(filled && { backgroundColor: theme?.palette.grey[200], minHeight: '48px' }),
-      ...(hasIcon ? { padding: 0 } : {})
+      ...(filled && { backgroundColor: theme?.palette.grey[200], minHeight: '48px' })
     },
     ['& .MuiCardHeader-avatar']: {
       ...(hasIcon && {


### PR DESCRIPTION
Remove setting padding to 0 when card header contains icon