### PR TITLE
fixed the render option problem

### DIFF
--- a/src/components/inputs/Autocomplete/types.ts
+++ b/src/components/inputs/Autocomplete/types.ts
@@ -3,7 +3,9 @@ import {
   AutocompleteChangeReason,
   AutocompleteCloseReason,
   AutocompleteInputChangeReason,
+  AutocompleteOwnerState,
   AutocompleteRenderInputParams,
+  AutocompleteRenderOptionState,
   AutocompleteValue,
   ChipTypeMap,
   AutocompleteProps as MuiAutocompleteProps
@@ -62,6 +64,7 @@ export interface AutocompleteProps<
     | 'onClose'
     | 'onInputChange'
     | 'renderInput'
+    | 'renderOption'
   > {
   /**
    * Array of options.
@@ -182,6 +185,21 @@ export interface AutocompleteProps<
    * @returns {ReactNode}
    */
   renderInput?: (params: AutocompleteRenderInputParams) => React.ReactNode
+  /**
+   * Render the option, use `getOptionLabel` by default.
+   *
+   * @param {object} props The props to apply on the li element.
+   * @param {Value} option The option to render.
+   * @param {object} state The state of each option.
+   * @param {object} ownerState The state of the Autocomplete component.
+   * @returns {ReactNode}
+   */
+  renderOption?: (
+    props: React.HTMLAttributes<HTMLLIElement> & { key: any },
+    option: T,
+    state: AutocompleteRenderOptionState,
+    ownerState: AutocompleteOwnerState<T, Multiple, DisableClearable, FreeSolo, ChipComponent>
+  ) => React.ReactNode
   /**
    * Label to be displayed in the heading component.
    */

--- a/src/stories/inputs/Autocomplete/Autocomplete.stories.tsx
+++ b/src/stories/inputs/Autocomplete/Autocomplete.stories.tsx
@@ -161,7 +161,8 @@ export const OptionRendering: Story = {
   },
   args: {
     label: 'Custom Options',
-    options: customOptions
+    options: customOptions,
+    loadOptions: loadFilteredOptionsPaginated
   },
   render: args => <CustomOptionPreview {...args} />
 }

--- a/src/stories/inputs/Autocomplete/CustomOptionPreview.tsx
+++ b/src/stories/inputs/Autocomplete/CustomOptionPreview.tsx
@@ -2,8 +2,10 @@
 // This source code is licensed under the MIT license.
 
 import React, { useState } from 'react'
-import { Autocomplete, Typography } from 'components'
+import { Autocomplete, AutocompleteProps, LoadOptionsPaginated, Typography } from 'components'
 import Box from '@mui/material/Box'
+import { Grid2 as Grid } from '@mui/material'
+import CheckIcon from '@mui/icons-material/Check'
 
 type OptionType = {
   id: number
@@ -13,24 +15,68 @@ type OptionType = {
 }
 
 export const CustomOptionPreview = (props: any) => {
-  const [value, setValue] = useState()
+  const [value, setValue] = useState<unknown>()
+  const { label, options, loadOptions } = props as AutocompleteProps<unknown>
+  // const loadUnknownOptions = loadOptions as LoadOptionsPaginated<unknown>
 
   return (
-    <Autocomplete
-      {...props}
-      value={value}
-      onChange={setValue}
-      renderOption={(props, option: OptionType) => (
-        <li {...props}>
-          <Box component={option.icon} width={25} height={25} marginRight="15px" />
-          <Box>
-            <Typography variant="body1">{option.name}</Typography>
-            <Typography variant="body2" color="error">
-              {option.description}
-            </Typography>
-          </Box>
-        </li>
-      )}
-    />
+    <Grid container spacing={2}>
+      <Grid size={{ md: 6, sm: 12 }}>
+        <Typography variant="caption" emphasis="bold">
+          Custom option preview
+        </Typography>
+      </Grid>
+      <Grid size={{ md: 6, sm: 12 }}>
+        <Typography variant="caption" emphasis="bold">
+          Custom option paginated
+        </Typography>
+      </Grid>
+      <Grid size={{ md: 6, sm: 12 }}>
+        <Autocomplete
+          creatable
+          label={label}
+          options={options}
+          value={value}
+          onChange={(v: unknown) => setValue(v)}
+          renderOption={(props: React.HTMLAttributes<HTMLLIElement> & { key: any }, unknownOption: unknown) => {
+            const option = unknownOption as OptionType
+            return (
+              <li {...props}>
+                <Box component={option.icon} width={25} height={25} marginRight="15px" />
+                <Box>
+                  <Typography variant="body1">{option.name}</Typography>
+                  <Typography variant="body2" color="error">
+                    {option.description}
+                  </Typography>
+                </Box>
+              </li>
+            )
+          }}
+        />
+      </Grid>
+      <Grid size={{ md: 6, sm: 12 }}>
+        <Autocomplete
+          label={label}
+          loadOptions={loadOptions}
+          isPaginated
+          value={value}
+          onChange={(v: unknown) => setValue(v)}
+          renderOption={(props: React.HTMLAttributes<HTMLLIElement> & { key: any }, unknownOption: unknown) => {
+            const option = unknownOption as OptionType
+            return (
+              <li {...props}>
+                <Box component={CheckIcon} width={25} height={25} marginRight="15px" />
+                <Box>
+                  <Typography variant="body1">{option.name}</Typography>
+                  <Typography variant="body2" color="error">
+                    {JSON.stringify(option)}
+                  </Typography>
+                </Box>
+              </li>
+            )
+          }}
+        />
+      </Grid>
+    </Grid>
   )
 }

--- a/src/stories/inputs/Autocomplete/CustomOptionPreview.tsx
+++ b/src/stories/inputs/Autocomplete/CustomOptionPreview.tsx
@@ -17,7 +17,6 @@ type OptionType = {
 export const CustomOptionPreview = (props: any) => {
   const [value, setValue] = useState<unknown>()
   const { label, options, loadOptions } = props as AutocompleteProps<unknown>
-  // const loadUnknownOptions = loadOptions as LoadOptionsPaginated<unknown>
 
   return (
     <Grid container spacing={2}>


### PR DESCRIPTION
Handled the custom internal option even if the user implements `renderOption`