### PR TITLE
removed default dividers value in dialog

### DIFF
--- a/src/components/feedback/Dialog/Dialog.tsx
+++ b/src/components/feedback/Dialog/Dialog.tsx
@@ -39,7 +39,7 @@ const Dialog: React.FC<DialogProps> = ({
   fullScreen,
   showX = true,
   transparentBackdrop,
-  dividers = false,
+  dividers,
   fullWidth = true,
   open = false,
   ...rest


### PR DESCRIPTION
Remove default value to `false` for dividers property in Dialog component. This was also the default in MaterialUI 