### PR TITLE
fixed closing calling loadOptions

### DIFF
--- a/src/components/inputs/Autocomplete/Autocomplete.tsx
+++ b/src/components/inputs/Autocomplete/Autocomplete.tsx
@@ -163,7 +163,7 @@ const Autocomplete: React.FC<
   )
 
   useEffect(() => {
-    if (!internalLoading || !loadOptions) return
+    if (!internalLoading || !loadOptions || !(open || internalOpen)) return
 
     const abortController = new AbortController()
     loadOptions(internalInputValue, allOptions.current, nextPageData, abortController.signal)
@@ -192,7 +192,7 @@ const Autocomplete: React.FC<
         new DOMException(`Aborted by Rocket UI for: "${internalInputValue}". New LoadOption was issued!`, 'AbortError')
       )
     }
-  }, [internalInputValue, internalLoading, isPaginated, loadOptions, nextPageData])
+  }, [internalInputValue, internalLoading, internalOpen, isPaginated, loadOptions, nextPageData, open])
 
   const handleRenderOption = useCallback(
     /**

--- a/src/stories/inputs/Autocomplete/DefaultPreview.tsx
+++ b/src/stories/inputs/Autocomplete/DefaultPreview.tsx
@@ -6,7 +6,7 @@ import { Autocomplete, Typography } from 'components'
 import { Stack } from '@mui/material'
 
 export const DefaultPreview = (props: any) => {
-  const [value, setValue] = useState(props?.value)
+  const [value, setValue] = useState(props?.value || null)
 
   return (
     <Stack spacing={1}>


### PR DESCRIPTION
When selecting an option and closing the component, it should not call loadOptions.